### PR TITLE
Ensure Sonar is running by waiting for a notification in the log file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,8 +58,11 @@
 - name: Ensure Sonar is running and set to start on boot.
   service: name=sonar state=started enabled=yes
 
-- name: Allow Sonar time to build on first start.
-  pause: seconds=180
+- name: Ensure Sonar is started.
+  wait_for:
+    path: /usr/local/sonar/logs/sonar.log
+    delay: 10
+    search_regex: 'app\[o\.s\.p\.m\.Monitor\] Process\[web\] is up'
   when: sonar_symlink.changed
   tags: ['skip_ansible_lint']
 


### PR DESCRIPTION
From olo-dw's fork submitted as [PR#27](https://github.com/geerlingguy/ansible-role-sonar/pull/27) upstream.