### PR TITLE
Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,15 @@ Same thing for databases versions:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `sonar_community_plugins` | List of community plugins to install. See below | `[]` |
 | `sonar_configuration` | See below | ... |
 | `sonar_download_url` | Source for SonarQube releases | `https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-{{ sonar_version }}.zip` |
 | `sonar_download_validate_certs` | Validate certificates for `sonar_download_url` | `true` |
 | `sonar_group` | UNIX sonar group | `sonar` |
 | `sonar_install_method` | See below | `move` |
+| `sonar_plugins` | List of official plugins to intsall. See below | `[]` |
 | `sonar_previous_version_backup` | Keep previous SonarQube version after upgrade | `false` |
+| `sonar_token` | Sonar security token, used to install plugins | `""` |
 | `sonar_user` | UNIX sonar user | `sonar` |
 | `sonar_version_directory` | Name of the installation directory | `sonarqube-{{ sonar_version }}` |
 | `sonar_version` | SonarQube version to install | `7.9` |
@@ -101,6 +104,52 @@ sonar_configuration:
     proxyHost: "{{ proxy_host }}"
     proxyPort: "{{ proxy_port }}"
 ```
+
+### sonar_plugins
+
+This variable is a list of dict describing a particular plugin:
+
+| Key | Description | Mandatory? |
+|-----|-------------|------------|
+| name | Plugin name | yes |
+| state | Either `absent` or `present` | no |
+
+It is mandatory to define a security token for an administrator account in the variable `sonar_token` for this functionality to work.
+
+Example:
+
+```yaml
+sonar_plugins:
+- name: Git
+- name: SonarPython
+- name: Svn
+  state: absent
+- name: Cvs
+  state: absent
+```
+
+### sonar_community_plugins
+
+This variable is a list of dict describing a particular plugin from the community:
+
+| Key | Description | Mandatory? |
+|-----|-------------|------------|
+| name | Plugin name | yes |
+| url | An URL pointing to jar | yes |
+| state | Either `absent` or `present` | no |
+
+Example:
+
+```yaml
+sonar_community_plugins:
+- name: backelite-sonar-swift
+  url: https://.../backelite-sonar-swift-plugin-0.4.5.jar
+- name: sonar-bad
+  url: https://.../sonar-bad-0.4.2.jar
+  state: absent
+```
+
+Note that the key `url` is mandatory, even when `state=absent`.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ sonar_group: "{{ sonar_user }}"
 
 # Default: move - Values: move, copy, link
 sonar_install_method: "move"
+sonar_token: ""
+sonar_plugins: []
+sonar_community_plugins: []
 
 sonar_configuration:
   sonar:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,6 +122,8 @@
     mode: 0600
   notify: restart sonar
 
+- include: plugins.yml
+
 - name: Ensure Sonar is running and set to start on boot.
   service: name=sonar state=started enabled=yes
 

--- a/tasks/plugin_update.yml
+++ b/tasks/plugin_update.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure {{ plugin.name }} is updated.
+  command: "curl -s -u {{ sonar_token }}: -d key={{ plugin.key }} {{ __sonar_api_base_url }}/plugins/update"
+  args:
+    warn: false
+  loop: "{{ plugin['updates'] }}"
+  loop_control:
+    loop_var: update
+    label: "{{ update['release']['version'] }}"
+  when: "'COMPATIBLE' == update['status']"
+  notify: restart sonar

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,0 +1,119 @@
+---
+- name: Ensure plugins folder exists.
+  file:
+    path: /usr/local/sonar/extensions/plugins
+    state: directory
+
+- set_fact:
+    __sonar_api_base_url: "http://localhost:{{ sonar_configuration.sonar.web.port }}{{ sonar_configuration.sonar.web.context | default('') }}/api"
+
+#
+# The uri module did not work for any of these usecases when testing with
+# ansible 2.8.1
+#
+
+- name: Official plugins.
+  block:
+
+  - name: Get the list of installed plugins.
+    command: "curl -s -u {{ sonar_token }}: {{ __sonar_api_base_url }}/plugins/installed"
+    args:
+      warn: false
+    register: installed
+    changed_when: false
+
+  - set_fact:
+      installed: "{{ installed.stdout | from_json }}"
+
+  - name: Ensure unwanted plugins are removed.
+    command: "curl -s -u {{ sonar_token }}: -d key={{ plugin.key }} {{ __sonar_api_base_url }}/plugins/uninstall"
+    args:
+      warn: false
+    loop: "{{ installed['plugins'] }}"
+    loop_control:
+      loop_var: plugin
+      label: "{{ plugin.name }}"
+    when:
+    - "plugin.name in sonar_plugins | json_query('[?state == `absent`].name')"
+    notify: restart sonar
+
+  # Apparently doesn't include already installed plugins, which is neat.
+  - name: Get the list of available plugins.
+    command: "curl -s -u {{ sonar_token }}: {{ __sonar_api_base_url }}/plugins/available"
+    args:
+      warn: false
+    register: available
+    changed_when: false
+
+  - set_fact:
+      available: "{{ available.stdout | from_json }}"
+
+  # Beware the monster task
+  - name: Ensure plugins are installed.
+    command: "curl -s -u {{ sonar_token }}: -d key={{ plugin.key }} {{ __sonar_api_base_url }}/plugins/install"
+    args:
+      warn: false
+    register: result
+    changed_when: "'is already installed' not in result.stdout"
+    notify: restart sonar
+    loop: "{{ available['plugins'] }}"
+    loop_control:
+      loop_var: plugin
+      label: "{{ plugin.name }}"
+    when:
+    - "plugin.name in sonar_plugins | json_query('[?state != `absent`].name')"
+
+  - name: Get the list of plugins needing an update.
+    command: "curl -s -u {{ sonar_token }}: {{ __sonar_api_base_url }}/plugins/updates"
+    args:
+      warn: false
+    register: updates
+    changed_when: false
+
+  - set_fact:
+      updates: "{{ updates.stdout | from_json }}"
+
+  - include_tasks: plugin_update.yml
+    loop: "{{ updates['plugins'] }}"
+    loop_control:
+      loop_var: plugin
+      label: "{{ plugin.name }}"
+
+  # Do not try to call the API after an upgrade as it won't be available
+  when:
+    - sonar_token
+    - sonar_application_version.stat.exists
+
+- name: Verify the status of community plugins.
+  stat:
+    path: "/usr/local/sonar/extensions/plugins/{{ plugin.url | urlsplit('path') | basename }}"
+  loop: "{{ sonar_community_plugins }}"
+  loop_control:
+    loop_var: plugin
+    label: "{{ plugin.name }}"
+  register: community_plugins
+
+- name: Remove unwanted community plugin.
+  file:
+    path: "/usr/local/sonar/extensions/plugins/{{ plugin.url | urlsplit('path') | basename }}"
+    state: absent
+  when:
+  - "plugin.state is defined"
+  - "plugin.state == 'absent'"
+  loop: "{{ sonar_community_plugins }}"
+  loop_control:
+    loop_var: plugin
+    label: "{{ plugin.name }}"
+  notify: restart sonar
+
+- name: Download community plugin.
+  get_url:
+    url: "{{ item['plugin']['url'] }}"
+    dest: /usr/local/sonar/extensions/plugins/
+  when:
+  - "not item['stat']['exists']"
+  - "(item['plugin']['state'] is not defined or (item['plugin']['state'] is defined and item['plugin']['state'] != 'absent'))"
+  loop: "{{ community_plugins.results }}"
+  loop_control:
+    label: "{{ item['plugin']['name'] }}"
+  notify: restart sonar


### PR DESCRIPTION
This PR allows the installation of plugins, both official and from the community, directly from Ansible.

Official plugins needs two things to work: first a SonarQube administrator must generates a security token and assigns it to `sonar_token` and second the instance must allows the update center, and thus have Internet access. Installation, update and removal through the api are supported. The most updated and compatible version of a plugin will always be choose.

Community plugins are fetched from anywhere you want: github, a local nexus, whatever is accessible by the [get_url](https://docs.ansible.com/ansible/latest/modules/get_url_module.html) module. It means offline installation of official plugins are possible too.

After a sonarqube upgrade plugins are still wiped out and thus needs to be installed again.